### PR TITLE
fix(k8s): use ca-cluster-issuer for proper TLS certificates

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
-    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    cert-manager.io/cluster-issuer: ca-cluster-issuer
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Switch from selfsigned-cluster-issuer to ca-cluster-issuer for proper TLS trust chain.